### PR TITLE
Support for NB 1.5.0 Hold my beer update

### DIFF
--- a/Nuclear Blaze Autosplitter.asl
+++ b/Nuclear Blaze Autosplitter.asl
@@ -1,3 +1,10 @@
+
+state("NuclearBlaze","1.5.0")
+{
+    int frame_timer : "libhl.dll", 0x5D3F8, 0x9D8, 0x28, 0x30, 0xA8, 0x18, 0x140; //contains the timers in frames
+    int X_position : "libhl.dll", 0x5D3F8, 0xA00, 0x0, 0x30, 0xC8, 0xC8, 0x34 //contains X position of the player
+}
+
 state("NuclearBlaze","1.0.3")
 {
     int frame_timer : "libhl.dll", 0x55FF0, 0x9B8, 0x8, 0x30, 0x140; //contains the timers in frames
@@ -33,6 +40,11 @@ init
     switch(MD5Hash){
         case "A29F2A7945A11B5E25F3B563DF9ACA0E" :
             version = "1.0.3";
+            vars.LEVEL_ID_LABEL = "y7:levelId";
+            break;
+        case "E92C6C32C6CFBE6E20664E095303AEFE" :
+            version = "1.5.0";
+            vars.LEVEL_ID_LABEL = "y11:bestLevelId";
             break;
         default :
             version = "Unknown Version";
@@ -106,7 +118,7 @@ start{
 //always running 
 //when returning true, reset the timer
 reset{
-    return current.frame_timer == -1;
+    return current.frame_timer <= 0;
 }
 
 //always running
@@ -122,13 +134,14 @@ update{
 
         if (vars.old_save[vars.current_save_id] != vars.new_save[vars.current_save_id]) {
             // Read Nuclear Blaze save format
-            var LEVEL_ID_LABEL = "y7:levelId";
             var current_save = vars.new_save[vars.current_save_id];
-            int idx_lvlId_label = current_save.IndexOf(LEVEL_ID_LABEL);
+            int idx_lvlId_label = current_save.IndexOf(vars.LEVEL_ID_LABEL);
+            print("u " + current_save);
             if (idx_lvlId_label > -1) {
-                if(current_save[idx_lvlId_label + LEVEL_ID_LABEL.Length] != 'n') {
+                var at_lvlId_idx = current_save[idx_lvlId_label + vars.LEVEL_ID_LABEL.Length];
+                if(at_lvlId_idx != 'n') {
                     // +10 to skip the y7:levelId, +1 to skip the y
-                    var save_substring = current_save.Substring(idx_lvlId_label + LEVEL_ID_LABEL.Length + 1); 
+                    var save_substring = current_save.Substring(idx_lvlId_label + vars.LEVEL_ID_LABEL.Length + 1); 
                     // save_substring should look like this "12:Intro_foresty11:gameVersiony5:1.0.3y4:diffoy[...]"
                     var idx_lvlId_label_length = save_substring.IndexOf(":"); // in that example, should give us 2
                     var levelId_length_str = save_substring.Substring(0, idx_lvlId_label_length); // in that example, should give us "12"

--- a/Nuclear Blaze Autosplitter.asl
+++ b/Nuclear Blaze Autosplitter.asl
@@ -42,11 +42,9 @@ init
     switch(MD5Hash){
         case "A29F2A7945A11B5E25F3B563DF9ACA0E" :
             version = "1.0.3";
-            vars.LEVEL_ID_LABEL = "y7:levelId";
             break;
         case "E92C6C32C6CFBE6E20664E095303AEFE" :
             version = "1.5.0";
-            vars.LEVEL_ID_LABEL = "y11:bestLevelId";
             break;
         default :
             version = "Unknown Version";
@@ -136,14 +134,23 @@ update{
 
         if (vars.old_save[vars.current_save_id] != vars.new_save[vars.current_save_id]) {
             // Read Nuclear Blaze save format
+            var LEVEL_ID_LABEL = "y7:levelId";
+            var BEST_LEVEL_ID_LABEL = "y11:bestLevelId";
             var current_save = vars.new_save[vars.current_save_id];
-            int idx_lvlId_label = current_save.IndexOf(vars.LEVEL_ID_LABEL);
+            int idx_lvlId_label = current_save.IndexOf(LEVEL_ID_LABEL);
             
             if (idx_lvlId_label > -1) {
-                var at_lvlId_idx = current_save[idx_lvlId_label + vars.LEVEL_ID_LABEL.Length];
+                var at_lvlId_idx = current_save[idx_lvlId_label + LEVEL_ID_LABEL.Length];
+                var lvlId_Label_to_use = LEVEL_ID_LABEL;
+                if(at_lvlId_idx == 'R') { // Redirect to reading Best level id instead
+                    lvlId_Label_to_use = BEST_LEVEL_ID_LABEL;
+                    idx_lvlId_label = current_save.IndexOf(BEST_LEVEL_ID_LABEL);
+                    at_lvlId_idx = current_save[idx_lvlId_label + lvlId_Label_to_use.Length];
+                }
+
                 if(at_lvlId_idx != 'n') {
                     // +10 to skip the y7:levelId, +1 to skip the y
-                    var save_substring = current_save.Substring(idx_lvlId_label + vars.LEVEL_ID_LABEL.Length + 1); 
+                    var save_substring = current_save.Substring(idx_lvlId_label + lvlId_Label_to_use.Length + 1); 
                     // save_substring should look like this "12:Intro_foresty11:gameVersiony5:1.0.3y4:diffoy[...]"
                     var idx_lvlId_label_length = save_substring.IndexOf(":"); // in that example, should give us 2
                     var levelId_length_str = save_substring.Substring(0, idx_lvlId_label_length); // in that example, should give us "12"

--- a/Nuclear Blaze Autosplitter.asl
+++ b/Nuclear Blaze Autosplitter.asl
@@ -2,13 +2,15 @@
 state("NuclearBlaze","1.5.0")
 {
     int frame_timer : "libhl.dll", 0x5D3F8, 0x9D8, 0x28, 0x30, 0xA8, 0x18, 0x140; //contains the timers in frames
-    int X_position : "libhl.dll", 0x5D3F8, 0xA00, 0x0, 0x30, 0xC8, 0xC8, 0x34 //contains X position of the player
+    int X_position : "libhl.dll", 0x5D3F8, 0xA00, 0x0, 0x30, 0xC8, 0xC8, 0x34; //contains X position of the player
+    int Y_position : "libhl.dll", 0x5D3F8, 0xA00, 0x0, 0x30, 0xC8, 0xC8, 0x38; //contains Y position of the player
 }
 
 state("NuclearBlaze","1.0.3")
 {
     int frame_timer : "libhl.dll", 0x55FF0, 0x9B8, 0x8, 0x30, 0x140; //contains the timers in frames
-    int X_position : "libhl.dll", 0x55FF0, 0x9C0, 0x0, 0x30, 0xC8, 0xC8, 0x34 //contains X position of the player
+    int X_position : "libhl.dll", 0x55FF0, 0x9C0, 0x0, 0x30, 0xC8, 0xC8, 0x34; //contains X position of the player
+    int Y_position : "libhl.dll", 0x55FF0, 0x9C0, 0x0, 0x30, 0xC8, 0xC8, 0x38; //contains Y position of the player
 }
 
 isLoading{
@@ -136,7 +138,7 @@ update{
             // Read Nuclear Blaze save format
             var current_save = vars.new_save[vars.current_save_id];
             int idx_lvlId_label = current_save.IndexOf(vars.LEVEL_ID_LABEL);
-            print("u " + current_save);
+            
             if (idx_lvlId_label > -1) {
                 var at_lvlId_idx = current_save[idx_lvlId_label + vars.LEVEL_ID_LABEL.Length];
                 if(at_lvlId_idx != 'n') {
@@ -171,12 +173,26 @@ split{
         return true;
     }
 
-    //if we are far enough in the right, it means we touched the final door
-    var touched_door = current.X_position > 24;
-
-    //if we are in the last level AND we are far enough in the right, we split (last split)
-    if (vars.levelId.Equals("Ending") && touched_door) {
-        print("SPLIT - Ending level id: " + vars.levelId.ToString() + ", touched door");
-        return true;
+    // Kill the chair ending check
+    if (vars.levelId.Equals("Ending")) {
+        //if we are far enough in the right, it means we touched the final door
+        var touched_door_X = current.X_position == 25;
+        var touched_door_Y = current.Y_position == 15;
+        
+        if (touched_door_X && touched_door_Y) {
+            print("SPLIT - Ending, touched door");
+            return true;
+        }
+    }
+    
+    // Ladder ending check
+    if (vars.levelId.Equals("Pumps_service_access")) {
+        var reached_ending_X = current.X_position == 39;
+        var reached_ending_Y = current.Y_position >= 7 && current.Y_position <= 9;
+        
+        if (reached_ending_X && reached_ending_Y) {
+            print("SPLIT - Ending, reached ladder ending");
+            return true;
+        }
     }
 }

--- a/NuclearBlaze.CT
+++ b/NuclearBlaze.CT
@@ -45,8 +45,23 @@
       </Offsets>
     </CheatEntry>
     <CheatEntry>
+      <ID>10</ID>
+      <Description>"Y position [1.5.0]"</Description>
+      <ShowAsSigned>0</ShowAsSigned>
+      <VariableType>4 Bytes</VariableType>
+      <Address>"libhl.dll"+0005D3F8</Address>
+      <Offsets>
+        <Offset>38</Offset>
+        <Offset>C8</Offset>
+        <Offset>C8</Offset>
+        <Offset>30</Offset>
+        <Offset>0</Offset>
+        <Offset>A00</Offset>
+      </Offsets>
+    </CheatEntry>
+    <CheatEntry>
       <ID>9</ID>
-      <Description>"Timer (in frames) [1.5.3]"</Description>
+      <Description>"Timer (in frames) [1.5.0]"</Description>
       <ShowAsSigned>0</ShowAsSigned>
       <VariableType>4 Bytes</VariableType>
       <Address>"libhl.dll"+0005D3F8</Address>
@@ -56,7 +71,22 @@
         <Offset>A8</Offset>
         <Offset>30</Offset>
         <Offset>28</Offset>
-        <Offset>9B8</Offset>
+        <Offset>9D8</Offset>
+      </Offsets>
+    </CheatEntry>
+    <CheatEntry>
+      <ID>11</ID>
+      <Description>"Level Timer (in frames) [1.5.0]"</Description>
+      <ShowAsSigned>0</ShowAsSigned>
+      <VariableType>4 Bytes</VariableType>
+      <Address>"libhl.dll"+0005D3F8</Address>
+      <Offsets>
+        <Offset>144</Offset>
+        <Offset>18</Offset>
+        <Offset>A8</Offset>
+        <Offset>30</Offset>
+        <Offset>28</Offset>
+        <Offset>9D8</Offset>
       </Offsets>
     </CheatEntry>
   </CheatEntries>

--- a/NuclearBlaze.CT
+++ b/NuclearBlaze.CT
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheatTable CheatEngineTableVersion="34">
+<CheatTable CheatEngineTableVersion="40">
   <CheatEntries>
     <CheatEntry>
       <ID>2</ID>
-      <Description>"X position in last screen"</Description>
-      <LastState Value="22" RealAddress="1E1A21B0C14"/>
+      <Description>"X position [1.0.3]"</Description>
       <ShowAsSigned>0</ShowAsSigned>
       <VariableType>4 Bytes</VariableType>
       <Address>"libhl.dll"+00055FF0</Address>
@@ -18,66 +17,8 @@
       </Offsets>
     </CheatEntry>
     <CheatEntry>
-      <ID>3</ID>
-      <Description>"X position in last screen 2"</Description>
-      <LastState Value="22" RealAddress="1E1A21B0C14"/>
-      <VariableType>4 Bytes</VariableType>
-      <Address>"libhl.dll"+00055FF0</Address>
-      <Offsets>
-        <Offset>34</Offset>
-        <Offset>C8</Offset>
-        <Offset>C8</Offset>
-        <Offset>30</Offset>
-        <Offset>8</Offset>
-        <Offset>9B8</Offset>
-      </Offsets>
-    </CheatEntry>
-    <CheatEntry>
-      <ID>4</ID>
-      <Description>"X position in last screen 3"</Description>
-      <LastState Value="22" RealAddress="1E1A21B0C14"/>
-      <VariableType>4 Bytes</VariableType>
-      <Address>"libhl.dll"+00055FF0</Address>
-      <Offsets>
-        <Offset>34</Offset>
-        <Offset>100</Offset>
-        <Offset>30</Offset>
-        <Offset>8</Offset>
-        <Offset>9B8</Offset>
-      </Offsets>
-    </CheatEntry>
-    <CheatEntry>
-      <ID>5</ID>
-      <Description>"X position in last screen 4"</Description>
-      <LastState Value="22" RealAddress="1E1A21B0C14"/>
-      <VariableType>4 Bytes</VariableType>
-      <Address>"libhl.dll"+00055FF0</Address>
-      <Offsets>
-        <Offset>34</Offset>
-        <Offset>100</Offset>
-        <Offset>30</Offset>
-        <Offset>0</Offset>
-        <Offset>9C0</Offset>
-      </Offsets>
-    </CheatEntry>
-    <CheatEntry>
-      <ID>6</ID>
-      <Description>"X position in last screen 5"</Description>
-      <LastState Value="22" RealAddress="1E1A21B0C14"/>
-      <VariableType>4 Bytes</VariableType>
-      <Address>"libhl.dll"+00055FF0</Address>
-      <Offsets>
-        <Offset>34</Offset>
-        <Offset>100</Offset>
-        <Offset>60</Offset>
-        <Offset>8</Offset>
-        <Offset>9B0</Offset>
-      </Offsets>
-    </CheatEntry>
-    <CheatEntry>
       <ID>7</ID>
-      <Description>"Timer (in frames)"</Description>
-      <LastState Value="16149" RealAddress="1E1AA341588"/>
+      <Description>"Timer (in frames) [1.0.3]"</Description>
       <ShowAsSigned>0</ShowAsSigned>
       <VariableType>4 Bytes</VariableType>
       <Address>"libhl.dll"+0x55FF0</Address>
@@ -86,6 +27,36 @@
         <Offset>0x30</Offset>
         <Offset>0x8</Offset>
         <Offset>0x9B8</Offset>
+      </Offsets>
+    </CheatEntry>
+    <CheatEntry>
+      <ID>8</ID>
+      <Description>"X position [1.5.0]"</Description>
+      <ShowAsSigned>0</ShowAsSigned>
+      <VariableType>4 Bytes</VariableType>
+      <Address>"libhl.dll"+0005D3F8</Address>
+      <Offsets>
+        <Offset>34</Offset>
+        <Offset>C8</Offset>
+        <Offset>C8</Offset>
+        <Offset>30</Offset>
+        <Offset>0</Offset>
+        <Offset>A00</Offset>
+      </Offsets>
+    </CheatEntry>
+    <CheatEntry>
+      <ID>9</ID>
+      <Description>"Timer (in frames) [1.5.3]"</Description>
+      <ShowAsSigned>0</ShowAsSigned>
+      <VariableType>4 Bytes</VariableType>
+      <Address>"libhl.dll"+0005D3F8</Address>
+      <Offsets>
+        <Offset>140</Offset>
+        <Offset>18</Offset>
+        <Offset>A8</Offset>
+        <Offset>30</Offset>
+        <Offset>28</Offset>
+        <Offset>9B8</Offset>
       </Offsets>
     </CheatEntry>
   </CheatEntries>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To download the autosplitter manually, go [here](https://raw.githubusercontent.c
 This autosplitter supports the following versions of Nuclear Blaze:
 
     Steam
+        1.5.0
         1.0.3
 
 If you wish to speedrun a non-Steam version of Nuclear Blaze, please get in touch with Evian on Discord (@Evian#6930) so that we can verify the autosplitter is functional for your version.


### PR DESCRIPTION
- Add 1.5.0 hash
- Add support for HMB mode ladder ending
- Added Y position to the variables read in memory
- Changed door ending check to include fixed y & x position to avoid splitting when explorer the secret "true ending" area
- For the HMB ladder ending check, checks range of y position because I think the timer can trigger while you're jumping
- Support NG+ by checking if levelId redirect to reading it's value or reading the value of bestLevelId instead

